### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-#Badass List of jQuery Plugins
+# Badass List of jQuery Plugins
 
 That's right. here I will be maintaining a list of very useful and handy jQuery plugins so that you don't have to search for the appropriate one while working in a project. If you want to add anything new, just fork this repo and send me a pull request. Have Fun!
 
@@ -8,45 +8,45 @@ This list is curated by [Hasin Hayder](http://hasin.me)
 
 
 
-###Carousels
+### Carousels
 [Owl Carousel](http://owlgraphic.com/owlcarousel/): A fantastic carousel plugin you can use in your responsive projects
 
-###CSS3 Animations & Transitions
+### CSS3 Animations & Transitions
 [Transit](http://ricostacruz.com/jquery.transit/): CSS3 Transition and Animation Library  
 [Nanimator](http://github.com/hasinhayder/Nanimator): jQuery Nano Animation library for content blocks  
 [ElementTransition](http://dan-silver.github.io/ElementTransitions.js/): Simple & beautiful transitions for web pages
 [Typed.js](http://www.mattboldt.com/demos/typed-js/): Beautiful text being typed animation.
 
-###Events
+### Events
 [TouchSwipe](http://www.awwwards.com/touchswipe-a-jquery-plugin-for-touch-and-gesture-based-interaction.html): A jQuery plugin for touch and gesture-based interaction  
 [Drag](http://threedubmedia.com/code/event/drag): A jquery special event plugin that makes the task of adding complex drag interactions, to any element.  
 [jQuery Hotkeys](https://github.com/jeresig/jquery.hotkeys): jQuery Hotkeys is a plug-in that lets you easily add and remove handlers for keyboard events anywhere in your code supporting almost any key combination.
 
 
-###Filtering & Sorting
+### Filtering & Sorting
 [Filter](http://www.jscraft.net/plugins/filters.html): A fantastic grid layout library with smart sorting :)  
 [MixItUp](http://mixitup.io/): An amazing library for different types of sorting and filtering. You will love it for sure!  
 [TableSorter](http://tablesorter.com/docs/): Easy and excellent table sorter plugin.
 [jQuery ListNav](http://esteinborn.github.io/jquery-listnav/): Excellent list filtering plugin 
 
-###Form Elements - Select Box
+### Form Elements - Select Box
 [Choosen](http://harvesthq.github.io/chosen): A jQuery Plugin by Harvest to Tame Unwieldy Select Boxes  
 [FancySelect](http://code.octopuscreative.com/fancyselect/): A better select for discerning web developers everywhere.  
 [Select2](http://ivaynberg.github.io/select2/): Select2 is a jQuery based replacement for select boxes. It supports searching, remote data sets, and infinite scrolling of results.
 
 
 
-###Form Validation
+### Form Validation
 [Parsley](https://github.com/guillaumepotier/Parsley.js): Javascript form validation, without actually writing a single line of javascript.
 
-###Image Processing, Canvas & SVG
+### Image Processing, Canvas & SVG
 [BlurJS](http://blurjs.com/): A jQuery plugin that produces psuedo-transparent 
 blurred elements over other elements  
 [TiltShift](http://www.noeltock.com/tilt-shift-css3-jquery-plugin/): Obtain Tiltshift/Mniature effect using this cool jQuery Plugin.
 
  
 
-###Layout
+### Layout
 [Isotope](http://isotope.metafizzy.co/): A complete layout library  
 [Masonry](http://masonry.desandro.com/): Layout library for Masonry grids  
 [Mason](https://github.com/DrewDahlman/Mason): jQuery Masonry grid with a very useful feature - columns with equal height  
@@ -54,17 +54,17 @@ blurred elements over other elements
 [FitJS](http://soulwire.github.io/fit.js/): Fit any div in any container, flawlessly.   
 [Gridster](http://gridster.net/): Gridster is a jQuery plugin that allows building intuitive draggable layouts from elements spanning multiple columns. You can even dynamically add and remove elements from the grid. 
 
-###Lazy Loading
+### Lazy Loading
 [Echo.Js](http://toddmotto.com/echo-js-simple-javascript-image-lazy-loading/): Simple JavaScript image lazy loading
 
-###Media Players
+### Media Players
 [jPlayer](http://jplayer.org/): The jQuery HTML5 Audio / Video Library
 
-###Mouse
+### Mouse
 [LazyMouse](http://hasinhayder.github.io/LazyMouse/): Detect Mouse Inactivity easily with this tiny jQuery Plugin.   
 
 
-###Scrolling and Parallax
+### Scrolling and Parallax
 [Scrollorama](http://johnpolacek.github.io/scrollorama/): The jQuery plugin for doing cool scrolly stuff  
 [Setller.js](http://markdalgleish.com/projects/stellar.js/): Parallax has bener been so easier  
 [Arbitrary Anchor](http://briangonzalez.org/arbitrary-anchor): ARBITRARY ANCHOR SCROLLING FOR ANY ELEMENT ON YOUR PAGE  
@@ -73,7 +73,7 @@ blurred elements over other elements
 [FullPage](http://alvarotrigo.com/fullPage): Create Beautiful Fullscreen Scrolling Websites
 
 
-###Sliders
+### Sliders
 [Responsive JS](http://responsive-slides.viljamis.com): A tiny responsive slider plugin with some cool features, in 1KB only  
 [Sequence JS](http://www.sequencejs.com/): The Slider Reimagined for the Modern Web, comes with fantastic CSS3 transitions and parallux  
 [Supersized](http://buildinternet.com/project/supersized): Fullscreen background slideshow plugin  
@@ -83,19 +83,19 @@ blurred elements over other elements
 [SliderJS](http://www.slidesjs.com/): SlidesJS is a responsive slideshow plug-in for jQuery (1.7.1+) with features like touch and CSS3 transitions.   
 [GlideJS](http://jedrzejchalubek.com/glide/): Responsive, lightweight and touch friendly slider that works in every device
 
-###Sound & Audio
+### Sound & Audio
 [Ion.Sound](http://ionden.com/a/plugins/ion.sound/en.html): Nifty jQuery library to play sound on events
 
-###Typography
+### Typography
 [CircleType.js](http://circletype.labwire.ca/): Circletype.js is a tiny (2.7kb) jQuery plugin that lets you set type on a circle and allows to use any font  
 [FitText](http://fittextjs.com/): Fittext makes any text to fit in the container of any size  
 [FlowType](http://simplefocus.com/flowtype/): Web typography at its finest: font-size and line-height based on element width.  
 
-###UI Elements - Calendar
+### UI Elements - Calendar
 [CLNDR](http://kylestetz.github.io/CLNDR/): A jQuery Calendar Plugin
 
 
-###UI Elements - Images, Galleries & Photos
+### UI Elements - Images, Galleries & Photos
 [TwentyTwenty - Before & After Differences](http://zurb.com/playground/twentytwenty): TwentyTwenty is a image difference tool which shows you the difference between two images visually  
 [Adipoli](http://cube3x.com/adipoli-jquery-image-hover-plugin/): Adipoli is a simple jQuery plugin used to bring stylish image hover effects  
 [BackStretch](http://srobbin.com/jquery-plugins/backstretch/): a simple jQuery plugin that allows you to add a dynamically-resized, slideshow-capable background image to any page or element  
@@ -107,14 +107,14 @@ blurred elements over other elements
 [LightGallery](http://sachinchoolur.github.io/lightGallery/): JQuery lightGallery is a lightweight jQuery lightbox gallery for displaying image and video in a gallery
 
 
-###UI Elements - Lightboxes & Modals
+### UI Elements - Lightboxes & Modals
 [Magnific Popup](http://dimsemenov.com/plugins/magnific-popup/): Magnific Popup is a responsive jQuery lightbox plugin that is focused on performance and providing best experience for user with any device  
 [FlipLightBox](http://flipgallery.net/fliplightbox.html): Responsive Lightbox jQuery Plugin  
 [PrettyPhoto](http://www.no-margin-for-errors.com/projects/prettyphoto-jquery-lightbox-clone/): PrettyPhoto is a jQuery lightbox clone. Not only does it support images, it also support for videos, flash, YouTube, iframes and ajax. It’s a full blown media lightbox.  
 [Remodal](http://vodkabears.github.io/remodal/): Flat, responsive, lightweight, easy customizable modal window plugin with declarative state notation and hash tracking.
 [Fluidbox](http://terrymun.github.io/Fluidbox/): Amazingly beautiful inline lightbox
 
-###UI Elements - Others
+### UI Elements - Others
 [JoyRide - Feature Tour Plugin](http://zurb.com/playground/jquery-joyride-feature-tour-plugin): As said, it's a beautiful feature tour plugin by Zurb.  
 [Hubspot Messaging Library](http://github.hubspot.com/messenger/): To show transactional messages in your app  
 [Bootrtrap Progressbar](http://www.minddust.com/bootstrap-progressbar/bootstrap-3.1.0.html): Animated progressbar that is compatible with bootstrap 3x  
@@ -124,36 +124,36 @@ blurred elements over other elements
 
 
 
-###UI Elements - Responsive Menu
+### UI Elements - Responsive Menu
 [FlexiNav](http://jasonweaver.name/lab/flexiblenavigation/): A Device-Agnostic Approach to Complex Site Navigation.   
 [SlimMenu](http://adnantopal.github.io/slimmenu): Another multilevel responsive menu  
 [SlideBars](http://plugins.adchsm.me/slidebars/): Slidebars is a jQuery plugin for quickly and easily implementing mobile app-style revealing menus and sidebars into your website.  
 [MMenu](http://mmenu.frebsite.nl/): A jQuery plugin for creating slick, app look-alike sliding menus for you mobile website with only one line of javascript
 
 
-###UI Elements - Scrollers
+### UI Elements - Scrollers
 [NanoScroller.js](http://jamesflorentino.github.io/nanoScrollerJS/): nanoScroller.js is a jQuery plugin that offers a simplistic way of implementing Mac OS X Lion-styled scrollbars for your website.  
 [NiceScroll](http://areaaperta.com/nicescroll/): Nicescroll is a jquery plugin, for nice scrollbars with a very similar ios/mobile style.
 
-###UI Elements - Social Sharing
+### UI Elements - Social Sharing
 [jQuery Tweetable](https://github.com/jmduke/jquery.tweetable.js): A simple li'l plugin that lets you make site content easily tweetable.  
 [Share-Button](https://github.com/carrot/share-button): fast, beautiful, and painless social shares  
 [Slide Social Button](http://christopheryee.ca/slide-social-buttons/): Slide Social Buttons are a fun way to display your social media buttons.
 
 
-###UI Elements - Tables
+### UI Elements - Tables
 [TableCloth.js](http://tableclothjs.com/): Tablecloth.js is a jQuery plugin that helps you easily style HTML tables along with some simple customizations.  
 [EditTable](http://codeb.it/edittable/): Adds editing capability in your table elements
 
 [jQery Data Table](https://datatables.net/): jQuery Data DataTables is a plug-in for the jQuery Javascript library. It is a highly flexible tool, based upon the foundations of progressive enhancement, and will add advanced interaction controls to any HTML table.
 
-###UI Elements - Toolbar
+### UI Elements - Toolbar
 [Toolbar.js](http://paulkinzett.github.io/toolbar/): A jQuery plugin that creates tooltip style toolbars
 
 
-###UI Elements - Tabs
+### UI Elements - Tabs
 [Tabulous.js](http://git.aaronlumsden.com/tabulous.js): A fantastic jQuery plugin to help you create tabs, easily  
 [NanoTabs](www.sunsean.com/nanotabs/): That's right - beautiful tabs in a nano sized plugin. 
 
-###UI Elements - WYSIWYG
+### UI Elements - WYSIWYG
 [SirTrevor](http://madebymany.github.io/sir-trevor-js/): A beautiful rich content editor reimagined for web.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
